### PR TITLE
安装可选依赖包

### DIFF
--- a/doc/tutorials/vm-qemu-oErv.md
+++ b/doc/tutorials/vm-qemu-oErv.md
@@ -32,6 +32,21 @@
 - 安装必要的构建工具
 
   `$ sudo apt install build-essential git libglib2.0-dev libfdt-dev libpixman-1-dev zlib1g-dev ninja-build`
+  
+- 安装可选依赖包
+
+  `$ sudo apt install libsdl2*`
+  `$ sudo apt-get install libslirp-dev`
+  `$ sudo apt-get install git-email`
+  `$ sudo apt-get install libaio-dev libbluetooth-dev libcapstone-dev libbrlapi-dev libbz2-dev`
+  `$ sudo apt-get install libcap-ng-dev libcurl4-gnutls-dev libgtk-3-dev`
+  `$ sudo apt-get install libibverbs-dev libjpeg8-dev libncurses5-dev libnuma-dev`
+  `$ sudo apt-get install librbd-dev librdmacm-dev`
+  `$ sudo apt-get install libsasl2-dev libsdl2-dev libseccomp-dev libsnappy-dev libssh-dev`
+  `$ sudo apt-get install libvde-dev libvdeplug-dev libvte-2.91-dev libxen-dev liblzo2-dev`
+  `$ sudo apt-get install valgrind xfslibs-dev`
+  `$ sudo apt-get install libnfs-dev libiscsi-dev`
+  
 - 创建 /usr/local 下的目标目录 `$ sudo mkdir -p /usr/local/bin/qemu-riscv64`
 - 下载最新的 QEMU 源码包 (修订时为 7.0.0 版本) `$ wget https://download.qemu.org/qemu-7.0.0.tar.xz`
 - 解压源码包并切换目录 `$ tar xvJf qemu-7.0.0.tar.xz && cd qemu-7.0.0`

--- a/doc/tutorials/vm-qemu-oErv.md
+++ b/doc/tutorials/vm-qemu-oErv.md
@@ -36,15 +36,25 @@
 - 安装可选依赖包
 
   `$ sudo apt install libsdl2*`
+  
   `$ sudo apt-get install libslirp-dev`
+  
   `$ sudo apt-get install git-email`
+  
   `$ sudo apt-get install libaio-dev libbluetooth-dev libcapstone-dev libbrlapi-dev libbz2-dev`
+  
   `$ sudo apt-get install libcap-ng-dev libcurl4-gnutls-dev libgtk-3-dev`
+  
   `$ sudo apt-get install libibverbs-dev libjpeg8-dev libncurses5-dev libnuma-dev`
+  
   `$ sudo apt-get install librbd-dev librdmacm-dev`
+  
   `$ sudo apt-get install libsasl2-dev libsdl2-dev libseccomp-dev libsnappy-dev libssh-dev`
+  
   `$ sudo apt-get install libvde-dev libvdeplug-dev libvte-2.91-dev libxen-dev liblzo2-dev`
+  
   `$ sudo apt-get install valgrind xfslibs-dev`
+  
   `$ sudo apt-get install libnfs-dev libiscsi-dev`
   
 - 创建 /usr/local 下的目标目录 `$ sudo mkdir -p /usr/local/bin/qemu-riscv64`

--- a/doc/tutorials/vm-qemu-oErv.md
+++ b/doc/tutorials/vm-qemu-oErv.md
@@ -35,7 +35,7 @@
   
 - 安装可选依赖包
   - 注：没装libsdl2*，那么xfce跑不起来
-  - 注：没装libslirp-dev，那么网络设备用不了  - 
+  - 注：没装libslirp-dev，那么网络设备用不了 
   
   `$ sudo apt install libsdl2*`
   

--- a/doc/tutorials/vm-qemu-oErv.md
+++ b/doc/tutorials/vm-qemu-oErv.md
@@ -34,7 +34,7 @@
   `$ sudo apt install build-essential git libglib2.0-dev libfdt-dev libpixman-1-dev zlib1g-dev ninja-build`
   
 - 安装可选依赖包
-  - 注：没装libsdl2*，那么xfce跑步起来
+  - 注：没装libsdl2*，那么xfce跑不起来
   - 注：没装libslirp-dev，那么网络设备用不了  - 
   
   `$ sudo apt install libsdl2*`

--- a/doc/tutorials/vm-qemu-oErv.md
+++ b/doc/tutorials/vm-qemu-oErv.md
@@ -34,7 +34,9 @@
   `$ sudo apt install build-essential git libglib2.0-dev libfdt-dev libpixman-1-dev zlib1g-dev ninja-build`
   
 - 安装可选依赖包
-
+  - 注：没装libsdl2*，那么xfce跑步起来
+  - 注：没装libslirp-dev，那么网络设备用不了  - 
+  
   `$ sudo apt install libsdl2*`
   
   `$ sudo apt-get install libslirp-dev`


### PR DESCRIPTION
为了面向功能更强大的应用，就有必要安装可选依赖包。
例如：
没装libsdl2*，那么xfce跑不起来
没装libslirp-dev，那么网络设备用不了